### PR TITLE
Fixed a special character issue on Windows.

### DIFF
--- a/src/snowcrypt/main.py
+++ b/src/snowcrypt/main.py
@@ -3,6 +3,8 @@ import json
 import queue
 import threading
 import logging
+import sys
+import re
 
 from os import path
 from datetime import datetime
@@ -59,6 +61,11 @@ def _get_args_for(file) -> list:
     tags = MP4.get(infile, encoding='MP4')
     title = tags.title.replace(' (Unabridged)', '')
     outfile = title + '.m4a'
+
+    #  Match Microsoft Windows reserved characters and control characters, replace
+    #  them with underline character ('_').
+    if sys.platform == 'win32':
+        outfile = re.sub(r'[<>:"/\\|?*\x00-\x1f]', '_', outfile)
 
     return [infile, outfile, key, iv]
 


### PR DESCRIPTION
Change(s):
  [1] This commit fixed an issue that the output filename can't be
      correctly determined on Windows when the title of an audiobook
	  contains any special character.

      For example, the title '君を守ろうとする猫の話: (小学館)' can't be
	  correctly handled due to the fact that it contains ':'
	  character.

	  To solve this problem, the changes in this commit will replace
	  all special characters with underline character ('_').

Contributor(s):
  [1] Ji WenCong <xiaojsoft@gmail.com>